### PR TITLE
ci: remove node v12 and add v16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  YARN_MODULES_CACHE_KEY: v1
-  YARN_PACKAGE_CACHE_KEY: v1
-  YARN_CACHE_FOLDER: .cache/yarn
   GIT_EMAIL: bot+ruby-semver@renovateapp.com
   NODE_VERSION: 14 # needs to be in sync with other v14 below
 
@@ -30,10 +27,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [12,14]
+        node-version: [14,16]
         exclude:
           - os: windows-latest
-            node-version: 12
+            node-version: 16
 
     env:
       coverage: ${{ matrix.os == 'ubuntu-latest' && matrix.node-version == 14 }}


### PR DESCRIPTION
Preparation for #102

`semantic-release` is no longer compatible with node v12 😕 