### PR TITLE
chore(deps): remove explicit dependency on `tslib`

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,6 @@
     "node": "^14.15.0 || ^16.13.0 || >= 18.12.0",
     "yarn": "^1.22.0"
   },
-  "dependencies": {
-    "tslib": "^2.5.0"
-  },
   "devDependencies": {
     "@renovate/eslint-plugin": "https://github.com/renovatebot/eslint-plugin#v0.0.5",
     "@types/jest": "29.5.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,7 @@
     "outDir": "./dist",
     /* https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping */
     "target": "ES2020",
-    "moduleResolution": "node",
-    "importHelpers": true
+    "moduleResolution": "node"
   },
   "exclude": ["node_modules", "dist"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -953,7 +953,6 @@
 
 "@renovate/eslint-plugin@https://github.com/renovatebot/eslint-plugin#v0.0.5":
   version "0.0.5"
-  uid "1923e2e2776549cb25a2c6ea09915ee31bff6d05"
   resolved "https://github.com/renovatebot/eslint-plugin#1923e2e2776549cb25a2c6ea09915ee31bff6d05"
 
 "@semantic-release/commit-analyzer@^9.0.2":
@@ -6410,7 +6409,7 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.1.0, tslib@^2.5.0:
+tslib@^2.1.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
   integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==


### PR DESCRIPTION
Looks like this was done back in #54 when there was a mix of dependencies on `tslib` `1.x` and `2.x`. This is no longer the case anymore, and I don't think this is required.