### PR TITLE
ci: use node v20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,13 +14,13 @@ concurrency:
 
 env:
   GIT_EMAIL: bot+ruby-semver@renovateapp.com
-  NODE_VERSION: 18 # needs to be in sync with other v18 below
+  NODE_VERSION: 20 # needs to be in sync with other v18 below
   DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
   DRY_RUN: true
 
 jobs:
   test:
-    name: ${{ matrix.node-version == 18 && format('test ({0})', matrix.os) || format('test ({0}, node-{1})', matrix.os, matrix.node-version) }}
+    name: ${{ matrix.node-version == 20 && format('test ({0})', matrix.os) || format('test ({0}, node-{1})', matrix.os, matrix.node-version) }}
     runs-on: ${{ matrix.os }}
 
     # tests shouldn't need more time
@@ -32,7 +32,7 @@ jobs:
         node-version: [18, 20]
 
     env:
-      coverage: ${{ matrix.os == 'ubuntu-latest' && matrix.node-version == 18 }}
+      coverage: ${{ matrix.os == 'ubuntu-latest' && matrix.node-version == 20 }}
       NODE_VERSION: ${{ matrix.node-version }}
 
     permissions:


### PR DESCRIPTION
run all jobs on node v20 (still running tests on v18 too)