### PR TITLE
Update codecov-action to v5.4.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
           path: coverage
 
       - name: Codecov
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
+        uses: codecov/codecov-action@39a2af19d997be74586469d4062e173ecae614f6 # v5.4.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
         if: env.coverage == 'true'


### PR DESCRIPTION
## Summary
- Updates codecov-action from v4.6.0 to v5.4.3 with hash 39a2af19d997be74586469d4062e173ecae614f6

This change aligns the codecov-action version with the renovate repository and updates to the latest version.